### PR TITLE
#7 Remove license footer at the bottom of README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,3 @@ If you see anything that can be improved, please feel free to suggest it or send
 Feel free to **Star** and **Watch** the Captain, but watch out for falling debris, and a wildly changing API.
 
 Feedback and contributions are always welcome and appreciated.
-
-### License
-
-Licensed under [MIT](https://github.com/DAVFoundation/captain/blob/master/LICENSE).


### PR DESCRIPTION
Remove license footer from README.md file

## Description
The license footer in the `README.md` file has become so this pull request is to remove it

## Related Issue
nil

## Motivation and Context


## How Has This Been Tested?

## Screenshots (if appropriate):
<img width="1061" alt="screen shot 2018-03-12 at 11 18 35 am" src="https://user-images.githubusercontent.com/23409769/37278180-29f7c6a8-25e7-11e8-803d-e381b2c0eca0.png">

## Types of changes
You can no longer see the license at the bottom of the README.md file

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.