### PR TITLE
test for ride-hailing/VehicleLocationMessageParams  #31

### DIFF
--- a/src/ride-hailing/VehicleLocationMessageParams.test.ts
+++ b/src/ride-hailing/VehicleLocationMessageParams.test.ts
@@ -1,0 +1,34 @@
+import MessageParams from './VehicleLocationMessageParams';
+
+describe('MessageParams class', () => {
+  const messageParams = new MessageParams({
+    vehicleLocation: {
+      lat: 32.050382,
+      long: 34.766149,
+    },
+    senderId: 'id',
+  });
+  const serializedMessageParams: any = {
+    missionStatus: 'on_the_way',
+    protocol: 'ride_hailing',
+    senderId: 'id',
+    ttl: undefined,
+    type: 'vehicle_location_message',
+    vehicleLocation: { lat: 32.050382, long: 34.766149 },
+  };
+
+  describe('serialize method', () => {
+    it('should return serialized need params object with the current values', () => {
+      expect(messageParams.serialize()).toEqual(serializedMessageParams);
+    });
+  });
+
+  describe('deserialize method', () => {
+    it('should return NeedParams instance with the current parameters', () => {
+      const messageParamsObject = new MessageParams();
+      messageParamsObject.deserialize(serializedMessageParams);
+      expect(messageParamsObject).toEqual(messageParams);
+    });
+  });
+
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added VehicleLocationMessageParams.test.ts  file in    src/ride-hailing

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is an open issue with name  Create tests for `ride-hailind/VehicleLocationMessageParams` using jest , and the link is https://github.com/DAVFoundation/dav-js/issues/31

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This test file helps  to check that the serialize and deserialize methods work as expected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed Jest in my  machine and ran  test with jest

## Screenshots (if appropriate):
![testsuccessmessage](https://user-images.githubusercontent.com/18584104/45264315-5ae6d880-b458-11e8-973a-4f5a78eb0e4a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.