### PR TITLE
Separate deserialize test into object type and contents

### DIFF
--- a/src/vessel-charging/messages/ChargingCompleteMessageParams.test.ts
+++ b/src/vessel-charging/messages/ChargingCompleteMessageParams.test.ts
@@ -19,7 +19,13 @@ describe('MessageParams class', () => {
   });
 
   describe('deserialize method', () => {
-    it('should return MessageParams instance with the current parameters', () => {
+    it('should return a MessageParams instance', () => {
+      const messageParamsObject = new MessageParams();
+      messageParamsObject.deserialize(serializedMessageParams);
+      expect(messageParamsObject).toBeInstanceOf(MessageParams);
+    });
+
+    it('should return the correct deserialized parameters', () => {
       const messageParamsObject = new MessageParams();
       messageParamsObject.deserialize(serializedMessageParams);
       expect(messageParamsObject).toEqual(messageParams);


### PR DESCRIPTION
## Description
Break `deserialize` test into testing for object type and deserialized contents check.

## Related Issue
Related to Issue #24 and comment:

https://github.com/DAVFoundation/dav-js/pull/61#issuecomment-424990744

## Motivation and Context
More secure testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.