### PR TITLE
#62 tsconfig - remove unnecessary commas from file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,10 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "lib": ["es2017", "dom"],
-    "outDir": "build",
+    "outDir": "build"
   },
   "include": [
     "src/**/*",
-    "samples/**/*",
-  ],
+    "samples/**/*"
+  ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I removed all trailing commas from the tsconfig.json file which makes it a valid JSON object.

## Related Issue
[Remove trailing commas in `tsconfig.json` (first-timers-only) #62](https://github.com/DAVFoundation/dav-js/issues/62)

## Motivation and Context
JSON does not allow a trailing comma, which means that if you run this file, you will get an error. Removing the commas will fix this. 

## How Has This Been Tested?
I ran `node tsconfig.json` with with the additional commas in place and received the following error
<img width="685" alt="screen shot 2018-09-29 at 11 09 08 am" src="https://user-images.githubusercontent.com/21162229/46249110-73ec0500-c3d8-11e8-9175-09a6eeab50aa.png">

After removing the trailing commas, I ran `node tsconfig.json` and received no errors
<img width="685" alt="screen shot 2018-09-29 at 11 13 13 am" src="https://user-images.githubusercontent.com/21162229/46249126-d513d880-c3d8-11e8-8bba-612c9eff5406.png">


## Screenshots (if appropriate):
### Before:
<img width="443" alt="trailingcomma" src="https://user-images.githubusercontent.com/21162229/46249157-83b81900-c3d9-11e8-8be0-739bee28f7ee.png">

### After:
<img width="458" alt="screen shot 2018-09-29 at 11 22 17 am" src="https://user-images.githubusercontent.com/21162229/46249199-ff19ca80-c3d9-11e8-868e-f739f9727d97.png">




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.