### PR TITLE
Update ChargingCompleteMessageParams.test.ts Issue #63

### DIFF
--- a/src/vessel-charging/messages/ChargingCompleteMessageParams.test.ts
+++ b/src/vessel-charging/messages/ChargingCompleteMessageParams.test.ts
@@ -1,16 +1,22 @@
 import MessageParams from './ChargingCompleteMessageParams';
 
 describe('MessageParams class', () => {
-  const messageParams = new MessageParams({
-    senderId: 'TOPIC_ID',
-  });
 
-  const serializedMessageParams: any = {
-    ttl: undefined,
-    protocol: 'vessel_charging',
-    type: 'charging_complete_message',
-    senderId: 'TOPIC_ID',
-  };
+  let messageParams: MessageParams;
+  let serializedMessageParams: any;
+
+  beforeEach(() => {
+    messageParams = new MessageParams({
+      senderId: 'TOPIC_ID',
+    });
+
+    serializedMessageParams = {
+      ttl: undefined,
+      protocol: 'vessel_charging',
+      type: 'charging_complete_message',
+      senderId: 'TOPIC_ID',
+    };
+  });
 
   describe('serialize method', () => {
     it('should return serialized message params object with the current values', () => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed ChargingCompleteMessageParams.test.ts parameters(messageParams and serializedMessageParams) to include them inside the BeforeEach() method provided by jest.

## Related Issue
#63 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Updated these parameters to make them more dynamic by defining them to be mutable similar to src/vessel-charging/MissionParams.test.ts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I run the tests again to check that everything was working properly.
## Screenshots (if appropriate):

## Types of changes
Improve test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.(Not applicable)
- [ ] All new and existing tests passed.(Not applicable)
- [x] Run again old tests to check refactoring didn't alter the result .