### PR TITLE
Update webpack and webpack-cli in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "tslint": "^5.11.0",
     "typedoc": "^0.11.1",
     "typescript": "^2.9.2",
-    "webpack": "^4.18.0",
-    "webpack-cli": "^2.1.5",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.1",
     "webpack-merge": "^4.1.4"
   }
 }


### PR DESCRIPTION
## Description

Running the tasks `build-browser-dev` and `build-browser-prod` was failing with an error from webpack:

```
TypeError: Cannot read property 'properties' of undefined
```

Updating the `webpack` package to 4.20.2 and the `webpack-cli` package to `3.3.1` resolves the error. 

## Motivation and Context

This is a known error, and is discussed [here](https://github.com/plotly/dash-component-boilerplate/issues/12) along with the solution. 

## How Has This Been Tested?

Running the tasks now proceeds - I'm getting a different error which I believe is unrelated, I'll track that in #121

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.