### PR TITLE
Fix Kafka tests

### DIFF
--- a/src/tests/Kafka.test.ts
+++ b/src/tests/Kafka.test.ts
@@ -96,7 +96,7 @@ describe('Kafka class', () => {
         price: 3,
         serialize: jest.fn(() => content),
       };
-      const paramsMockType = jest.fn<BasicParams>(() => content);
+      const paramsMockType = jest.fn<BasicParams, [string, string]>(() => content);
       const paramsMock = new paramsMockType();
 
       const clientMock = {
@@ -127,11 +127,12 @@ describe('Kafka class', () => {
     xit('should get error from producer while trying to connect to kafka', async () => {
       jest.doMock('kafka-node');
       const kafka = (await import('../Kafka')).default;
-      const paramsMockType = jest.fn<BasicParams>(() => ({
+      const content: any = {
         serialize: () => {
           return 'basic params mock content';
         },
-      }));
+      };
+      const paramsMockType = jest.fn<BasicParams, [string, string]>(() => content);
       const paramsMock = new paramsMockType();
 
       const clientMock = {
@@ -158,7 +159,7 @@ describe('Kafka class', () => {
         price: 3,
         serialize: jest.fn(() => content),
       };
-      const paramsMockType = jest.fn<BasicParams>(() => content);
+      const paramsMockType = jest.fn<BasicParams, [string, string]>(() => content);
       const paramsMock = new paramsMockType();
 
       const clientMock = {
@@ -395,7 +396,7 @@ describe('Kafka class', () => {
           price: 3,
           serialize: jest.fn(() => paramsObject),
         };
-        const paramsMockType = jest.fn<BasicParams>(() => paramsObject);
+        const paramsMockType = jest.fn<BasicParams, [string, string]>(() => paramsObject);
         const paramsMock = new paramsMockType();
 
         const postMock = jest.fn((url: string, content: string, conf: any) =>
@@ -424,7 +425,7 @@ describe('Kafka class', () => {
           price: 3,
           serialize: jest.fn(() => paramsObject),
         };
-        const paramsMockType = jest.fn<BasicParams>(() => paramsObject);
+        const paramsMockType = jest.fn<BasicParams, [string, string]>(() => paramsObject);
         const paramsMock = new paramsMockType();
 
         const postMock = jest.fn((url: string, conf: any) =>
@@ -453,7 +454,7 @@ describe('Kafka class', () => {
           price: 3,
           serialize: jest.fn(() => paramsObject),
         };
-        const paramsMockType = jest.fn<BasicParams>(() => paramsObject);
+        const paramsMockType = jest.fn<BasicParams, [string, string]>(() => paramsObject);
         const paramsMock = new paramsMockType();
 
         const postMock = jest.fn((url: string, conf: any) =>


### PR DESCRIPTION
Add argument types for BasicParams mocks to fix issues with Kafka-related tests

## Related Issue

Presumably, #139 is related. Please, note that this PR addresses only Kafka tests issues, so after merging Travis will still fail because of failing Contracts tests (see PR #141).

## Motivation and Context

Kafka tests were failing.

## How Has This Been Tested?

npm run jest

$ node -v
v10.15.3
$ npm -v
6.4.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement that improves upon existing functionality

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
