### PR TITLE
Fix Contacts tests

### DIFF
--- a/src/tests/Contracts.test.ts
+++ b/src/tests/Contracts.test.ts
@@ -125,7 +125,11 @@ describe('Contracts class', () => {
 
     it('should call relevant functions and throw web3 error', async () => {
       isRegisteredCall.mockImplementation(() => false);
-      sendSignedTransactionSuccess.mockImplementation(() => false);
+      const web3 = require('web3');
+      web3.eth.sendSignedTransaction = jest.fn(() => ({
+        once: jest.fn(() => false),
+        on: (type: string, cb: any) => jest.fn(cb(web3Error)),
+      }));
       const contracts: any = (await import('../Contracts')).default;
       await expect(
         contracts.registerIdentity(
@@ -182,7 +186,11 @@ describe('Contracts class', () => {
     });
 
     it('should call relevant functions and throw web3 error', async () => {
-      sendSignedTransactionSuccess.mockImplementation(() => false);
+      const web3 = require('web3');
+      web3.eth.sendSignedTransaction = jest.fn(() => ({
+        once: jest.fn(() => false),
+        on: (type: string, cb: any) => jest.fn(cb(web3Error)),
+      }));
       const contracts: any = (await import('../Contracts')).default;
       await expect(
         contracts.approveMission(
@@ -193,7 +201,7 @@ describe('Contracts class', () => {
       ).rejects.toBe(web3Error);
       expect(approve).toHaveBeenCalled();
       expect(signTransaction).toHaveBeenCalled();
-      expect(sendSignedTransaction).toHaveBeenCalled();
+      expect(web3.eth.sendSignedTransaction).toHaveBeenCalled();
     });
   });
 
@@ -241,7 +249,11 @@ describe('Contracts class', () => {
     });
 
     it('should call relevant functions and throw web3 error', async () => {
-      sendSignedTransactionSuccess.mockImplementation(() => false);
+      const web3 = require('web3');
+      web3.eth.sendSignedTransaction = jest.fn(() => ({
+        once: jest.fn(() => false),
+        on: (type: string, cb: any) => jest.fn(cb(web3Error)),
+      }));
       const contracts: any = (await import('../Contracts')).default;
       await expect(
         contracts.startMission(
@@ -255,7 +267,7 @@ describe('Contracts class', () => {
       ).rejects.toBe(web3Error);
       expect(create).toHaveBeenCalled();
       expect(signTransaction).toHaveBeenCalled();
-      expect(sendSignedTransaction).toHaveBeenCalled();
+      expect(web3.eth.sendSignedTransaction).toHaveBeenCalled();
     });
   });
 
@@ -301,7 +313,11 @@ describe('Contracts class', () => {
     });
 
     it('should call relevant functions and throw web3 error', async () => {
-      sendSignedTransactionSuccess.mockImplementation(() => false);
+      const web3 = require('web3');
+      web3.eth.sendSignedTransaction = jest.fn(() => ({
+        once: jest.fn(() => false),
+        on: (type: string, cb: any) => jest.fn(cb(web3Error)),
+      }));
       const contracts: any = (await import('../Contracts')).default;
       await expect(
         contracts.finalizeMission(
@@ -313,7 +329,7 @@ describe('Contracts class', () => {
       ).rejects.toBe(web3Error);
       expect(fulfilled).toHaveBeenCalled();
       expect(signTransaction).toHaveBeenCalled();
-      expect(sendSignedTransaction).toHaveBeenCalled();
+      expect(web3.eth.sendSignedTransaction).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Correctly define sendSignedTransaction in web3.eth mock to fix the contracts tests that throw web3 error

## Related Issue

Presumably, #139 is related. Please, note that this PR addresses only Contracts tests issues, so after merging Travis will still fail because of failing Kafka tests (see PR https://github.com/DAVFoundation/dav-js/pull/140).

## Motivation and Context

Contracts tests were failing.

## How Has This Been Tested?

npm run jest

$ node -v
v10.15.3
$ npm -v
6.4.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement that improves upon existing functionality

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
